### PR TITLE
Added support for new features and made bug fixes.

### DIFF
--- a/ToolWindow/Package.vsct
+++ b/ToolWindow/Package.vsct
@@ -20,12 +20,6 @@
   <!--This header contains the command ids for the menus provided by the shell. -->
   <Extern href="vsshlids.h"/>
 
-  <!--Definition of some VSCT specific constants. In this sample we use it for the IDs inside the guidOfficeIcon group. -->
-  <Extern href="msobtnid.h"/>
-
-
-
-
   <!--The Commands section is where we the commands, menus and menu groups are defined.
       This section uses a Guid to identify the package that provides the command defined inside it. -->
   <Commands package="guidMarkdownPackagePkg">

--- a/ToolWindow/PreviewToolWindow.cs
+++ b/ToolWindow/PreviewToolWindow.cs
@@ -64,11 +64,15 @@ namespace MarkdownMode
                         return; // doesn't look like a relative uri
                     }
 
-                    string documentName =
-                        new FileInfo(this.path).ResolveRelativePath(
-                            args.Uri.LocalPath.Replace('/', Path.DirectorySeparatorChar));
+                    string documentName = new FileInfo(this.path).ResolveRelativePath(
+                        args.Uri.LocalPath.Replace('/', Path.DirectorySeparatorChar));
 
-                    if (documentName == null || !File.Exists(documentName))
+                    // If there is a file name but it doesn't exist and doesn't have an extension, try adding
+                    // ".md" (GitHub style target in a literal anchor link).
+                    if(documentName != null && !File.Exists(documentName) && Path.GetExtension(documentName).Length == 0)
+                        documentName += ".md";
+
+                    if(documentName == null || !File.Exists(documentName))
                     {
                         return; // relative path could not be resolved, or does not exist
                     }
@@ -117,7 +121,7 @@ namespace MarkdownMode
 
             bool sameSource = source == this.source;
             this.source = source;
-            this.html = html;
+            this.html = (html ?? String.Empty);
             this.title = title;
             this.path = path;
 

--- a/ToolWindow/PreviewWindowBackgroundParser.cs
+++ b/ToolWindow/PreviewWindowBackgroundParser.cs
@@ -34,13 +34,170 @@ namespace MarkdownMode
         string GetHTMLText(string text, bool extraSpace)
         {
             StringBuilder html = new StringBuilder();
-            html.AppendLine("<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"></head><body>");
+
+            // The style sheet could probably be moved into an embedded resource or perhaps made configurable.
+            // For now, it's just hard-coded.
+            html.AppendLine(@"<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv=""X-UA-Compatible"" content=""edge"" />
+<meta charset=""utf-8\"">
+<style>
+body {
+	margin: 15px;
+	font-family: ""Helvetica Neue"", Helvetica, ""Segoe UI"", Arial, sans-serif;
+	font-size: 16px;
+	line-height: 1.6;
+}
+
+h1 {
+	padding-bottom: 0.3em;
+	font-size: 2.25em;
+	line-height: 1.2;
+}
+
+h2 {
+	padding-bottom: 0.3em;
+	font-size: 1.75em;
+	line-height: 1.225;
+}
+
+h3 {
+	font-size: 1.5em;
+	line-height: 1.43;
+}
+
+h4 {
+	font-size: 1.25em;
+}
+
+h5 {
+	font-size: 1em;
+}
+
+h6 {
+	font-size: 1em;
+	color: #777;
+}
+
+p, blockquote, ul, ol, dl, table, pre {
+	margin-top: 0;
+	margin-bottom: 16px;
+}
+
+hr {
+	height: 4px;
+	padding: 0;
+	margin: 16px 0;
+	background-color: #e7e7e7;
+	border: 0 none;
+}
+
+ul, ol {
+	padding-left: 2em;
+}
+
+ul ul, ul ol, ol ol, ol ul {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+li > p {
+	margin-top: 16px;
+}
+
+dl {
+	padding: 0;
+}
+
+dl dt {
+	padding: 0;
+	margin-top: 16px;
+	font-size: 1em;
+	font-style: italic;
+	font-weight: bold;
+}
+
+dl dd {
+	padding: 0 16px;
+	margin-bottom: 16px;
+}
+
+blockquote {
+	padding: 0 15px;
+	color: #777;
+	border-left: 4px solid #ddd;
+}
+
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+	display: block;
+	width: 100%;
+	word-break: normal;
+	word-break: keep-all;
+}
+
+table th {
+	font-weight: bold;
+}
+
+table th, table td {
+	padding: 6px 13px;
+	border: 1px solid #ddd;
+}
+
+table tr {
+	background-color: #fff;
+	border-top: 1px solid #ccc;
+}
+
+img {
+	border: 0;
+}
+
+kbd {
+	display: inline-block;
+	padding: 3px 5px;
+	font-size: 11px;
+	line-height: 10px;
+	color: #555;
+	vertical-align: middle;
+	background-color: #fcfcfc;
+	border: solid 1px #ccc;
+	border-bottom-color: #bbb;
+	border-radius: 3px;
+	box-shadow: inset 0 -1px 0 #bbb;
+}
+
+code, tt {
+	font-family: Consolas, ""Courier New"", monospace;
+}
+
+pre {
+	margin-top: 0;
+	margin-bottom: 16px;
+    padding: 10px;
+	font-family: Consolas, ""Courier New"", monospace;
+	background-color: #f7f7f7;
+	border-radius: 3px;
+}
+
+pre code, pre tt {
+	font-family: Consolas, ""Courier New"", monospace;
+}
+</style>
+</head>
+<body>");
+
             html.AppendLine(markdownTransform.Transform(text, markdownDocumentPath));
+
             if (extraSpace)
             {
                 for (int i = 0; i < 20; i++)
                     html.Append("<br />");
             }
+
             html.AppendLine("</body></html>");
 
             return html.ToString();

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -21,8 +21,11 @@
       <VisualStudio Version="12.0">
         <Edition>Pro</Edition>
       </VisualStudio>
+      <VisualStudio Version="14.0">
+        <Edition>Pro</Edition>
+      </VisualStudio>
     </SupportedProducts>
-    <SupportedFrameworkRuntimeEdition MinVersion="4.0" MaxVersion="4.0" />
+    <SupportedFrameworkRuntimeEdition MinVersion="4.0" MaxVersion="4.5" />
   </Identifier>
   <References />
   <Content>


### PR DESCRIPTION
- Added support for GitHub style fenced code blocks.
- Added code to fully qualify relative image filename paths in literal
HTML img elements.
- Updated the manifest to allow installation in VS 2015.
- Removed the msobtnid.h include in Package.vsct which isn't used and is
no longer present in newer versions of Visual Studio.
- When navigating in the preview tool window, if there is a filename but
it doesn't exist and doesn't have an extension, try adding ".md" (GitHub
style target in a literal anchor link).
- Fixed a bug in SetPreviewContent() to prevent a crash in a rare case
where null was passed for the html parameter but had a non-null title.
- Added a basic stylesheet to the HTML wrapper which makes the rendered
content much easier to read especially when it contains code blocks and
tables.