### PR TITLE
Null reference fix

### DIFF
--- a/ToolWindow/PreviewToolWindow.cs
+++ b/ToolWindow/PreviewToolWindow.cs
@@ -152,7 +152,7 @@ namespace MarkdownMode
                 scrollBackTo = null;
             }
 
-            browser.NavigateToString(html);
+            browser.NavigateToString(this.html);
         }
 
         public void ClearPreviewContent()


### PR DESCRIPTION
This completes a fix from the prior pull request that prevents a null reference exception under certain conditions when navigating quickly between topics.