### PR TITLE
Fix meta tag for utf-8 encoding in preview window

### DIFF
--- a/ToolWindow/PreviewWindowBackgroundParser.cs
+++ b/ToolWindow/PreviewWindowBackgroundParser.cs
@@ -41,7 +41,7 @@ namespace MarkdownMode
 <html>
 <head>
 <meta http-equiv=""X-UA-Compatible"" content=""edge"" />
-<meta charset=""utf-8\"">
+<meta charset=""utf-8"">
 <style>
 body {
 	margin: 15px;


### PR DESCRIPTION
The current implementation contains an escape character, which finds its way into the final html. That's not good for umlauts or the like...
